### PR TITLE
feat: 퀴즈 생성 후, 저장

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^7.6.2",
+    "react-spinners": "^0.17.0",
     "react-toastify": "^11.0.5",
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,0 @@
-export default function App() {
-  return <></>;
-}

--- a/src/components/api/postApi.ts
+++ b/src/components/api/postApi.ts
@@ -13,6 +13,23 @@ export const getChannelPosts = async (channelId: number) => {
   }
 };
 
+export const getChannelCategoryPosts = async (
+  channelId: number,
+  category: string,
+) => {
+  try {
+    const { data: posts } = await supabase
+      .from('post')
+      .select('*')
+      .eq('channel', channelId)
+      .contains('tags', [category]);
+
+    return posts;
+  } catch (e) {
+    console.error(e);
+  }
+};
+
 export const getPost = async (postId: number) => {
   try {
     const { data: post } = await supabase

--- a/src/components/atoms/ModalButton.tsx
+++ b/src/components/atoms/ModalButton.tsx
@@ -15,7 +15,7 @@ export default function ModalButton({
     <>
       <button
         className={twMerge(
-          'bg-gray3 t4 hover:bg-gray4 h-6 w-20 rounded-[4px] text-center text-white md:h-8 md:w-25',
+          'bg-gray3 t4 hover:bg-gray4 h-8 w-25 rounded-[10px] text-center text-white md:h-10 md:w-34',
           className,
         )}
         type={type}

--- a/src/components/atoms/Navigation.tsx
+++ b/src/components/atoms/Navigation.tsx
@@ -21,7 +21,7 @@ const menuItems: MenuItem[] = [
   {
     name: '문제게시판',
     path: '/problems',
-    requiresLogin: true,
+    // requiresLogin: true,
     Icon: FileText,
     subItems: [
       { name: '알고리즘문제', path: '/problems/coding' },

--- a/src/components/detail/QuizComponent.tsx
+++ b/src/components/detail/QuizComponent.tsx
@@ -1,14 +1,16 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import QuizChooseBox from '../atoms/QuizChooseBox';
 import { ChevronDown, ChevronRight, Plus, Trash2, X } from 'lucide-react';
 import { twMerge } from 'tailwind-merge';
 import type { QuizItem } from '../../types/quizList';
+import { notify } from '../../utils/customAlert';
 
 type JobQuizProps = {
   index: number;
   item: QuizItem;
   onDelete: (index: number) => void;
   onChange: (index: number, value: QuizItem) => void;
+  onValid?: (valid: boolean) => void;
 };
 
 export default function QuizComponent({
@@ -16,9 +18,22 @@ export default function QuizComponent({
   item,
   onDelete,
   onChange,
+  onValid,
 }: JobQuizProps) {
   const { description, quiz } = item;
-  const [isShow, setShow] = useState(false);
+  const [isShow, setShow] = useState(true);
+
+  const isValid = () => {
+    const hasDescription = description.trim() !== '';
+    const hasSelected = quiz.filter((v) => v.selected).length >= 1;
+    const hasValue = quiz.every((v) => v.value.trim() !== '');
+    return hasDescription && hasSelected && hasValue;
+  };
+
+  useEffect(() => {
+    const valid = isValid();
+    onValid?.(valid);
+  }, [description, quiz]);
 
   const updateDescription = (newVal: string) => {
     onChange(index, { ...item, description: newVal });
@@ -27,6 +42,19 @@ export default function QuizComponent({
   const updateQuiz = (id: string, newVal: string) => {
     const update = quiz.map((v) => (v.id === id ? { ...v, value: newVal } : v));
     onChange(index, { ...item, quiz: update });
+  };
+
+  const createQuiz = () => {
+    if (isValid()) {
+      setShow(false);
+      notify('퀴즈를 생성했습니다!', 'success');
+    } else {
+      notify('퀴즈가 완성되지 않았습니다!', 'warning');
+    }
+  };
+  const deleteQuiz = () => {
+    onDelete(index);
+    notify('퀴즈를 삭제했습니다!', 'success');
   };
 
   const toggleSelect = (id: string) => {
@@ -44,7 +72,7 @@ export default function QuizComponent({
       { id: 'D', selected: false, value: '' },
     ];
     onChange(index, { description: '', quiz: reset });
-    setShow(false);
+    notify('퀴즈가 초기화 되었습니다!', 'warning');
   };
   return (
     <>
@@ -59,7 +87,7 @@ export default function QuizComponent({
           <div className="flex-grow"></div>
           {isShow ? (
             <ChevronDown
-              onClick={() => setShow(false)}
+              onClick={() => isValid() && setShow(false)}
               className={twMerge(
                 'text-gray4',
                 'mt-[-6px] mr-[-6px] cursor-pointer md:mt-0 md:mr-[-8px]',
@@ -104,13 +132,10 @@ export default function QuizComponent({
                 <span className="ml-[3px]">취소</span>
               </div>
               <div className="flex-grow"></div>
-              <div
-                onClick={() => onDelete(index)}
-                className="button-quiz delete"
-              >
+              <div onClick={deleteQuiz} className="button-quiz delete">
                 <Trash2 size={16} />
               </div>
-              <div onClick={() => setShow(false)} className="button-quiz plus">
+              <div onClick={createQuiz} className="button-quiz plus">
                 <Plus className="ml-[7px]" size={16} />
                 <span className="ml-[3px]">생성</span>
               </div>

--- a/src/components/edit/CreateQuiz.tsx
+++ b/src/components/edit/CreateQuiz.tsx
@@ -16,6 +16,7 @@ export default forwardRef<CreateQuizHandle, CreateQuizProps>(
   function CreateQuiz({ problems }, ref) {
     const editorRef = useRef<Editor>(null);
     const titleRef = useRef<HTMLInputElement>(null);
+    const [category, setCategory] = useState<string>('기타');
 
     useImperativeHandle(ref, () => ({
       getPostData: () => {
@@ -24,7 +25,8 @@ export default forwardRef<CreateQuizHandle, CreateQuizProps>(
         const match = content.match(/!\[.*?\]\((.*?)\)/g);
         const imageUrl = match?.[0]?.match(/\((.*?)\)/)?.[1] || null;
         const imageFileName = imageUrl?.split('/').pop() || null;
-        return { title, content, imageUrl, imageFileName };
+        const tags = [category];
+        return { title, content, imageUrl, imageFileName, tags };
       },
     }));
 
@@ -128,10 +130,23 @@ export default forwardRef<CreateQuizHandle, CreateQuizProps>(
                   <p className="mb-1.5 text-sm md:text-base">카테고리</p>
                   <div className="flex flex-wrap gap-2.5">
                     <div className="mb-4 flex flex-wrap gap-2.5">
-                      <CheckItem id="1" title="프론트엔드" />
-                      <CheckItem id="2" title="백엔드" />
-                      <CheckItem id="3" title="모바일 앱" />
-                      <CheckItem id="4" title="기타" />
+                      <CheckItem
+                        id="1"
+                        title="프론트엔드"
+                        onChange={setCategory}
+                      />
+                      <CheckItem id="2" title="백엔드" onChange={setCategory} />
+                      <CheckItem
+                        id="3"
+                        title="모바일 앱"
+                        onChange={setCategory}
+                      />
+                      <CheckItem
+                        id="4"
+                        title="기타"
+                        onChange={setCategory}
+                        checked={category === '기타'}
+                      />
                     </div>
                   </div>
                 </div>

--- a/src/components/edit/CreateQuiz.tsx
+++ b/src/components/edit/CreateQuiz.tsx
@@ -69,6 +69,7 @@ export default forwardRef<CreateQuizHandle, CreateQuizProps>(
 
     const deleteQuiz = (index: number) => {
       setQuizList((v) => v.filter((_, i) => i !== index));
+      setValidList((v) => v.filter((_, i) => i !== index));
     };
 
     const updateQuiz = (index: number, value: QuizItem) => {

--- a/src/components/edit/CreateQuiz.tsx
+++ b/src/components/edit/CreateQuiz.tsx
@@ -2,116 +2,169 @@
 import { Plus } from 'lucide-react';
 import QuizComponent from '../detail/QuizComponent';
 import CheckItem from '../ui/CheckItem';
-import { useRef, useState } from 'react';
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import type { QuizItem } from '../../types/quizList';
+import type { CreateQuizHandle, CreateQuizProps } from './EditText.types';
+import { Editor } from '@toast-ui/react-editor';
+import codeSyntaxHighlight from '@toast-ui/editor-plugin-code-syntax-highlight';
+// @ts-expect-error: prismjs has no type declarations
+import Prism from 'prismjs';
+import 'prismjs/themes/prism.css';
+import supabase from '../../utils/supabase';
 
-export default function EditText({ problems }: { problems?: boolean }) {
-  const [quizList, setQuizList] = useState<QuizItem[]>([]);
-  const currentPos = useRef<HTMLDivElement | null>(null);
+export default forwardRef<CreateQuizHandle, CreateQuizProps>(
+  function CreateQuiz({ problems }, ref) {
+    const editorRef = useRef<Editor>(null);
+    const titleRef = useRef<HTMLInputElement>(null);
 
-  const addQuiz = () => {
-    const newQuiz: QuizItem = {
-      description: '',
-      quiz: [
-        { id: 'A', selected: false, value: '' },
-        { id: 'B', selected: false, value: '' },
-        { id: 'C', selected: false, value: '' },
-        { id: 'D', selected: false, value: '' },
-      ],
+    useImperativeHandle(ref, () => ({
+      getPostData: () => {
+        const title = titleRef.current?.value.trim() || '';
+        const content = editorRef.current?.getInstance().getMarkdown() || '';
+        const match = content.match(/!\[.*?\]\((.*?)\)/g);
+        const imageUrl = match?.[0]?.match(/\((.*?)\)/)?.[1] || null;
+        const imageFileName = imageUrl?.split('/').pop() || null;
+        return { title, content, imageUrl, imageFileName };
+      },
+    }));
+
+    const [quizList, setQuizList] = useState<QuizItem[]>([]);
+    const currentPos = useRef<HTMLDivElement | null>(null);
+
+    const addQuiz = () => {
+      const newQuiz: QuizItem = {
+        description: '',
+        quiz: [
+          { id: 'A', selected: false, value: '' },
+          { id: 'B', selected: false, value: '' },
+          { id: 'C', selected: false, value: '' },
+          { id: 'D', selected: false, value: '' },
+        ],
+      };
+
+      setQuizList((v) => [...v, newQuiz]);
+      setTimeout(() => {
+        currentPos.current?.scrollIntoView({
+          block: 'start',
+          behavior: 'smooth',
+        });
+      }, 100);
     };
 
-    setQuizList((v) => [...v, newQuiz]);
-    setTimeout(() => {
-      currentPos.current?.scrollIntoView({
-        block: 'start',
-        behavior: 'smooth',
-      });
-    }, 100);
-  };
+    const deleteQuiz = (index: number) => {
+      setQuizList((v) => v.filter((_, i) => i !== index));
+    };
 
-  const deleteQuiz = (index: number) => {
-    setQuizList((v) => v.filter((_, i) => i !== index));
-  };
+    const updateQuiz = (index: number, value: QuizItem) => {
+      setQuizList((v) => v.map((q, i) => (i === index ? value : q)));
+    };
+    return (
+      <>
+        <div className="lg:grid lg:grid-cols-2 lg:gap-12">
+          {problems && (
+            <div className="h-full w-full lg:grid lg:grid-rows-[auto_1fr] lg:pb-9">
+              <p className="mb-2.5 text-sm md:text-base lg:text-lg">문제</p>
+              <div className="mb-7 h-[250px] overflow-auto rounded-sm bg-[var(--color-bg-white)] p-2.5 text-xs md:text-sm lg:h-full lg:text-base">
+                문제내용..
+              </div>
+            </div>
+          )}
+          <form className={`col-span-2 w-full ${problems && 'lg:col-span-1'}`}>
+            <div className="mb-[25px] md:mb-[35px]">
+              <p className="mb-2.5 text-sm md:text-base lg:text-lg">제목</p>
+              <input
+                className="edit-input mb-5"
+                type="text"
+                placeholder="제목을 입력하세요"
+                ref={titleRef}
+              />
+              <div className="mb-2.5 flex items-end">
+                <p className="text-sm md:text-base lg:text-lg">내용</p>
+              </div>
+              <div className="mb-5 min-h-[300px] rounded-sm border border-[#ccc] text-xs md:text-sm lg:text-base">
+                <Editor
+                  ref={editorRef}
+                  initialValue="내용을 입력하세요."
+                  previewStyle="tab"
+                  initialEditType="markdown"
+                  useCommandShortcut={true}
+                  plugins={[[codeSyntaxHighlight, { highlighter: Prism }]]}
+                  hooks={{
+                    addImageBlobHook: async (
+                      blob: Blob,
+                      callback: (url: string, altText: string) => void,
+                    ) => {
+                      const fileExt = blob.type.split('/')[1];
+                      const today = new Date();
+                      const yyyymmdd = today
+                        .toISOString()
+                        .slice(0, 10)
+                        .replace(/-/g, '');
+                      const fileName = `${yyyymmdd}/${Date.now()}.${fileExt}`;
 
-  const updateQuiz = (index: number, value: QuizItem) => {
-    setQuizList((v) => v.map((q, i) => (i === index ? value : q)));
-  };
-  return (
-    <>
-      <div className="lg:grid lg:grid-cols-2 lg:gap-12">
-        {problems && (
-          <div className="h-full w-full lg:grid lg:grid-rows-[auto_1fr] lg:pb-9">
-            <p className="mb-2.5 text-sm md:text-base lg:text-lg">문제</p>
-            <div className="mb-7 h-[250px] overflow-auto rounded-sm bg-[var(--color-bg-white)] p-2.5 text-xs md:text-sm lg:h-full lg:text-base">
-              문제내용..
-            </div>
-          </div>
-        )}
-        <form className={`col-span-2 w-full ${problems && 'lg:col-span-1'}`}>
-          <div className="mb-[25px] md:mb-[35px]">
-            <p className="mb-2.5 text-sm md:text-base lg:text-lg">제목</p>
-            <input
-              className="edit-input mb-5"
-              type="text"
-              placeholder="제목을 입력하세요"
-            />
-            <div className="mb-2.5 flex items-end">
-              <p className="text-sm md:text-base lg:text-lg">내용</p>
-              {/* <div className="ml-auto flex gap-2">
-                <button className="button-sm">
-                  <StickyNote className="h-[14px] w-[12px] shrink-0" /> 템플릿
-                  불러오기
-                </button>
-                <button className="button-sm">
-                  <StickyNote className="h-[14px] w-[12px] shrink-0" />
-                  템플릿 저장
-                </button>
-              </div> */}
-            </div>
-            <div className="mb-5 min-h-[300px] rounded-sm border border-[#ccc] text-xs md:text-sm lg:text-base">
-              에디터영역
-            </div>
-            <div className="flex flex-wrap gap-2.5">
-              <div className="mb-2">
-                <p className="mb-1.5 text-sm md:text-base">카테고리</p>
-                <div className="flex flex-wrap gap-2.5">
-                  <div className="mb-4 flex flex-wrap gap-2.5">
-                    <CheckItem id="1" title="프론트엔드" />
-                    <CheckItem id="2" title="백엔드" />
-                    <CheckItem id="3" title="모바일 앱" />
-                    <CheckItem id="4" title="기타" />
+                      const { error } = await supabase.storage
+                        .from('post-images')
+                        .upload(fileName, blob);
+
+                      if (error) {
+                        console.error('이미지 업로드 실패:', error.message);
+                        return;
+                      }
+
+                      const { data } = supabase.storage
+                        .from('post-images')
+                        .getPublicUrl(fileName);
+
+                      const imageUrl = data?.publicUrl;
+                      if (imageUrl) {
+                        callback(imageUrl, 'image');
+                      }
+                    },
+                  }}
+                />
+              </div>
+              <div className="flex flex-wrap gap-2.5">
+                <div className="mb-2">
+                  <p className="mb-1.5 text-sm md:text-base">카테고리</p>
+                  <div className="flex flex-wrap gap-2.5">
+                    <div className="mb-4 flex flex-wrap gap-2.5">
+                      <CheckItem id="1" title="프론트엔드" />
+                      <CheckItem id="2" title="백엔드" />
+                      <CheckItem id="3" title="모바일 앱" />
+                      <CheckItem id="4" title="기타" />
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div className="mb-2 flex flex-col gap-[10px]">
-              <p className="text-sm md:text-base">퀴즈생성</p>
-              {quizList.map((v, i) => (
-                <div
-                  key={i}
-                  ref={i === quizList.length - 1 ? currentPos : null}
+              <div className="mb-2 flex flex-col gap-[10px]">
+                <p className="text-sm md:text-base">퀴즈생성</p>
+                {quizList.map((v, i) => (
+                  <div
+                    key={i}
+                    ref={i === quizList.length - 1 ? currentPos : null}
+                  >
+                    <QuizComponent
+                      index={i}
+                      item={v}
+                      onDelete={deleteQuiz}
+                      onChange={updateQuiz}
+                    />
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={addQuiz}
+                  disabled={quizList.length >= 10 ? true : false}
+                  className="bg-gray3 t3 flex h-[40px] w-full cursor-pointer items-center justify-center rounded-[4px] text-white transition hover:shadow-lg active:bg-black disabled:hidden"
                 >
-                  <QuizComponent
-                    index={i}
-                    item={v}
-                    onDelete={deleteQuiz}
-                    onChange={updateQuiz}
-                  />
-                </div>
-              ))}
-              <button
-                type="button"
-                onClick={addQuiz}
-                disabled={quizList.length >= 10 ? true : false}
-                className="bg-gray3 t3 flex h-[40px] w-full cursor-pointer items-center justify-center rounded-[4px] text-white transition hover:shadow-lg active:bg-black disabled:hidden"
-              >
-                <Plus size={24} />
-                <span className="ml-[3px]">문제 추가</span>
-              </button>
+                  <Plus size={24} />
+                  <span className="ml-[3px]">문제 추가</span>
+                </button>
+              </div>
             </div>
-          </div>
-        </form>
-      </div>
-    </>
-  );
-}
+          </form>
+        </div>
+      </>
+    );
+  },
+);

--- a/src/components/edit/EditText.types.ts
+++ b/src/components/edit/EditText.types.ts
@@ -25,5 +25,6 @@ export interface CreateQuizHandle {
     content: string;
     imageUrl: string | null;
     imageFileName: string | null;
+    tags: string[];
   };
 }

--- a/src/components/edit/EditText.types.ts
+++ b/src/components/edit/EditText.types.ts
@@ -1,3 +1,5 @@
+import type { QuizItem } from '../../types/quizList';
+
 export interface EditTextProps {
   tags: string[];
   onAddTag: (val: string) => void;
@@ -16,7 +18,7 @@ export interface EditTextHandle {
 }
 
 export interface CreateQuizProps {
-  problems?: boolean;
+  quizValid: (valid: boolean) => void;
 }
 
 export interface CreateQuizHandle {
@@ -26,5 +28,6 @@ export interface CreateQuizHandle {
     imageUrl: string | null;
     imageFileName: string | null;
     tags: string[];
+    quizData: QuizItem[];
   };
 }

--- a/src/components/edit/EditText.types.ts
+++ b/src/components/edit/EditText.types.ts
@@ -14,3 +14,16 @@ export interface EditTextHandle {
     tags: string[];
   };
 }
+
+export interface CreateQuizProps {
+  problems?: boolean;
+}
+
+export interface CreateQuizHandle {
+  getPostData: () => {
+    title: string;
+    content: string;
+    imageUrl: string | null;
+    imageFileName: string | null;
+  };
+}

--- a/src/components/list/QuizListCard.tsx
+++ b/src/components/list/QuizListCard.tsx
@@ -1,7 +1,9 @@
 import { Check, Heart } from 'lucide-react';
 import Avartar from '../ui/Avartar';
-import type { PostType } from '../../types';
+import type { PostType, User } from '../../types';
 import { format } from 'date-fns';
+import { getUser } from '../api/userApi';
+import { useEffect, useState } from 'react';
 
 // 임시로 지정한 props 입니다
 export default function QuizListCard({
@@ -11,69 +13,89 @@ export default function QuizListCard({
   data: PostType;
   solve?: boolean;
 }) {
+  const [user, setUser] = useState<User>(null);
+  const [isPending, setPending] = useState(false);
+  useEffect(() => {
+    const fetchData = async () => {
+      setPending(true);
+      try {
+        const userData = await getUser(data.author);
+        setUser(userData);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setPending(false);
+      }
+    };
+    fetchData();
+  }, [data.author]);
   return (
     <>
-      {/* 스켈레톤 */}
-      {/* <div className="w-full rounded-sm border border-[#ccc]">
-        <div className="px-3 pt-3.5 pb-3 md:px-4 md:pt-4 md:pb-3.5">
-          <div className="mb-2.5 h-3.5 w-2/3 bg-gray-200 md:h-4.5 lg:h-5.5"></div>
-          <div className="mb-1 h-3 w-full bg-gray-200 md:h-4 lg:h-5"></div>
-          <div className="mb-2.5 h-3 w-4/5 bg-gray-200 md:h-4 lg:h-5"></div>
-          <div className="h-2.5 w-1/3 bg-gray-200 md:h-3.5 lg:h-4.5"></div>
+      {isPending ? (
+        <div className="w-full rounded-sm border border-[#ccc]">
+          <div className="px-3 pt-3.5 pb-3 md:px-4 md:pt-4 md:pb-3.5">
+            <div className="mb-2.5 h-3.5 w-2/3 bg-gray-200 md:h-4.5 lg:h-5.5"></div>
+            <div className="mb-1 h-3 w-full bg-gray-200 md:h-4 lg:h-5"></div>
+            <div className="mb-2.5 h-3 w-4/5 bg-gray-200 md:h-4 lg:h-5"></div>
+            <div className="h-2.5 w-1/3 bg-gray-200 md:h-3.5 lg:h-4.5"></div>
+          </div>
+          <div className="flex w-full items-center gap-2 border-t border-[#ccc] px-3 py-2 md:px-4 md:py-2.5">
+            <div className="h-[24px] w-[24px] rounded-full bg-gray-200 md:h-[26px] md:w-[26px] lg:h-[28px] lg:w-[28px]"></div>
+            <div className="h-3 w-1/2 bg-gray-200 md:h-4 lg:h-5"></div>
+          </div>
         </div>
-        <div className="flex w-full items-center gap-2 border-t border-[#ccc] px-3 py-2 md:px-4 md:py-2.5">
-          <div className="h-[24px] w-[24px] rounded-full bg-gray-200 md:h-[26px] md:w-[26px] lg:h-[28px] lg:w-[28px]"></div>
-          <div className="h-3 w-1/2 bg-gray-200 md:h-4 lg:h-5"></div>
-        </div>
-      </div> */}
-
-      <div className="w-full rounded-sm border border-[#ccc]">
-        <div className="px-3 pt-3.5 pb-3 md:px-4 md:pt-4 md:pb-3.5">
-          <div className="flex gap-2.5">
-            <div className="w-[calc(100%-110px)] md:w-[calc(100%-130px)] lg:w-[calc(100%-150px)]">
-              <p className="mb-2.5 text-sm font-semibold md:text-base lg:text-lg">
-                {data.title}
-              </p>
-              <p className="mb-2.5 line-clamp-2 text-xs md:text-sm lg:text-base">
-                {data.content}
-              </p>
-            </div>
-            {data.image && (
-              <div className="ml-auto h-[65px] w-[85px] shrink-0 overflow-hidden md:h-[75px] md:w-[105px] lg:h-[85px] lg:w-[125px]">
-                <img src={data.image} className="h-full w-full object-cover" />
+      ) : (
+        <div className="w-full rounded-sm border border-[#ccc]">
+          <div className="px-3 pt-3.5 pb-3 md:px-4 md:pt-4 md:pb-3.5">
+            <div className="flex gap-2.5">
+              <div className="w-[calc(100%-110px)] md:w-[calc(100%-130px)] lg:w-[calc(100%-150px)]">
+                <p className="mb-2.5 text-sm font-semibold md:text-base lg:text-lg">
+                  {data.title}
+                </p>
+                <p className="mb-2.5 line-clamp-2 text-xs md:text-sm lg:text-base">
+                  {data.content}
+                </p>
               </div>
+              {data.image && (
+                <div className="ml-auto h-[65px] w-[85px] shrink-0 overflow-hidden md:h-[75px] md:w-[105px] lg:h-[85px] lg:w-[125px]">
+                  <img
+                    src={data.image}
+                    className="h-full w-full object-cover"
+                  />
+                </div>
+              )}
+            </div>
+            <ul className="mb-2.5 flex gap-3">
+              {data.tags &&
+                data.tags.map((v) => (
+                  <li className="rounded-sm bg-[var(--color-gray1)] px-2 py-0.5 text-[10px] text-[var(--color-gray4)] md:text-xs lg:text-sm">
+                    {v}
+                  </li>
+                ))}
+            </ul>
+            <div className="flex items-end">
+              <span className="text-[10px] text-[var(--color-gray3)] md:text-xs lg:text-sm">
+                {format(new Date(data.created_at), 'yyyy-MM-dd')}
+              </span>
+              <div className="ml-auto flex shrink-0 gap-3">
+                <div className="flex items-center gap-1">
+                  <Heart className="w-3.5 md:w-4 lg:w-4.5" />
+                  <span className="text-[10px] md:text-xs lg:text-sm">5</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="flex w-full items-center border-t border-[#ccc] px-3 py-2 md:px-4 md:py-2.5">
+            <Avartar user={user} />
+            {solve && (
+              <p className="ml-auto flex items-center gap-1 text-[10px] md:text-xs lg:text-sm">
+                <Check className="w-4 text-[var(--color-green-info)] md:w-5 lg:w-6" />
+                풀이됨
+              </p>
             )}
           </div>
-          <ul className="mb-2.5 flex gap-3">
-            <li className="rounded-sm bg-[var(--color-gray1)] px-2 py-0.5 text-[10px] text-[var(--color-gray4)] md:text-xs lg:text-sm">
-              태그명
-            </li>
-            <li className="rounded-sm bg-[var(--color-gray1)] px-2 py-0.5 text-[10px] text-[var(--color-gray4)] md:text-xs lg:text-sm">
-              태그명
-            </li>
-          </ul>
-          <div className="flex items-end">
-            <span className="text-[10px] text-[var(--color-gray3)] md:text-xs lg:text-sm">
-              {format(new Date(data.created_at), 'yyyy-MM-dd')}
-            </span>
-            <div className="ml-auto flex shrink-0 gap-3">
-              <div className="flex items-center gap-1">
-                <Heart className="w-3.5 md:w-4 lg:w-4.5" />
-                <span className="text-[10px] md:text-xs lg:text-sm">5</span>
-              </div>
-            </div>
-          </div>
         </div>
-        <div className="flex w-full items-center border-t border-[#ccc] px-3 py-2 md:px-4 md:py-2.5">
-          <Avartar />
-          {solve && (
-            <p className="ml-auto flex items-center gap-1 text-[10px] md:text-xs lg:text-sm">
-              <Check className="w-4 text-[var(--color-green-info)] md:w-5 lg:w-6" />
-              풀이됨
-            </p>
-          )}
-        </div>
-      </div>
+      )}
     </>
   );
 }

--- a/src/components/list/QuizListCard.tsx
+++ b/src/components/list/QuizListCard.tsx
@@ -67,9 +67,9 @@ export default function QuizListCard({
             </div>
             <ul className="mb-2.5 flex gap-3">
               {data.tags &&
-                data.tags.map((v) => (
+                data.tags.map((tag) => (
                   <li className="rounded-sm bg-[var(--color-gray1)] px-2 py-0.5 text-[10px] text-[var(--color-gray4)] md:text-xs lg:text-sm">
-                    {v}
+                    {tag}
                   </li>
                 ))}
             </ul>

--- a/src/components/modals/IsLoginModal.tsx
+++ b/src/components/modals/IsLoginModal.tsx
@@ -11,6 +11,12 @@ interface IsLoginModalProps {
 export default function IsLoginModal({ isOpen, onClose }: IsLoginModalProps) {
   const navigate = useNavigate();
   const modalRef = useRef<HTMLDivElement>(null);
+
+  const handleConfirm = () => {
+    navigate('/login');
+    onClose();
+  };
+
   // 바깥 클릭 감지
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -44,7 +50,10 @@ export default function IsLoginModal({ isOpen, onClose }: IsLoginModalProps) {
   if (!isOpen) return null;
   return (
     <>
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div
+        onClick={onClose}
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      >
         <div
           ref={modalRef}
           className="relative flex h-[190px] w-[280px] flex-col items-center justify-center gap-5 rounded-sm bg-white px-[30px] pt-[20px] pb-[25px] drop-shadow-md md:h-[240px] md:w-[360px] md:gap-10 md:px-[40px] md:pt-[30px] md:pb-[40px]"
@@ -66,7 +75,7 @@ export default function IsLoginModal({ isOpen, onClose }: IsLoginModalProps) {
           <div className="flex w-full flex-row justify-between">
             <ModalButton onClick={onClose}>아니오</ModalButton>
             <ModalButton
-              onClick={() => navigate('/login')}
+              onClick={handleConfirm}
               className="bg-sub1 hover:bg-main"
             >
               예

--- a/src/components/ui/Avartar.tsx
+++ b/src/components/ui/Avartar.tsx
@@ -1,16 +1,21 @@
-export default function Avartar() {
+import type { User } from '../../types';
+
+export default function Avartar({ user }: { user?: User }) {
   return (
     <>
       <div className="flex items-center gap-2">
         <div className="h-[24px] w-[24px] overflow-hidden rounded-full border border-[#eee] md:h-[26px] md:w-[26px] lg:h-[28px] lg:w-[28px]">
           <img
             className="h-full w-full object-cover"
-            src="https://www.studiopeople.kr/common/img/default_profile.png"
+            src={
+              user?.image ||
+              'https://www.studiopeople.kr/common/img/default_profile.png'
+            }
           />
         </div>
         <div>
           <span className="text-[10px] text-[#464646] md:text-xs lg:text-sm">
-            사용자이름
+            {user?.fullname || '익명'}
           </span>
         </div>
       </div>

--- a/src/components/ui/CheckItem.tsx
+++ b/src/components/ui/CheckItem.tsx
@@ -1,18 +1,27 @@
 export default function CheckList({
   id,
   title,
+  onChange,
+  checked,
 }: {
   id: string;
   title: string;
+  onChange: (title: string) => void;
+  checked?: boolean;
 }) {
+  const handleChange = () => {
+    onChange(title);
+  };
   return (
     <>
       <div>
         <input
-          type="checkbox"
+          type="radio"
           name="tag"
           id={title + id}
           className="peer absolute appearance-none opacity-0"
+          onChange={handleChange}
+          checked={checked}
         />
         <label
           htmlFor={title + id}

--- a/src/components/ui/Loading.tsx
+++ b/src/components/ui/Loading.tsx
@@ -1,0 +1,11 @@
+import { FadeLoader } from 'react-spinners';
+
+export default function Loading() {
+  return (
+    <>
+      <div className="z-50 flex h-50 items-center justify-center">
+        <FadeLoader color="var(--color-sub1)" speedMultiplier={5} />
+      </div>
+    </>
+  );
+}

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -87,7 +87,7 @@ export default function Header() {
             <Bell />
             <img
               src={userInfo.avatar_url || userDefault}
-              alt="userProfile"
+              alt="프로필"
               className="h-7 cursor-pointer rounded-full lg:h-8"
               onClick={() => setDropdownOpen(!dropdownOpen)}
             />

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -1,18 +1,18 @@
 import { useEffect, useState } from 'react';
 import Sidebar from './Sidebar';
 import { Bell, Menu } from 'lucide-react';
-import IsLoginModal from '../components/modals/IsLoginModal';
 import { useAuthStore } from '../stores/authStore';
 import supabase from '../utils/supabase';
 import { useNavigate } from 'react-router';
 import Navigation from '../components/atoms/Navigation';
 import userDefault from '../assets/images/icon-user-default.png';
 import DropdownMenu from '../components/modals/DropdownMenu';
+import { useModalStore } from '../stores/modalStore';
 
 export default function Header() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [isLoginOpen, setLoginOpen] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const { setLogInModal } = useModalStore();
   const isLogin = useAuthStore((state) => state.isLogin);
   const setLogout = useAuthStore((state) => state.setLogout);
   const navigate = useNavigate();
@@ -22,7 +22,7 @@ export default function Header() {
   ) => {
     if (!isLogin) {
       e.preventDefault();
-      setLoginOpen(true);
+      setLogInModal(true);
     }
   };
 
@@ -126,7 +126,6 @@ export default function Header() {
         )}
       </header>
       <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
-      <IsLoginModal isOpen={isLoginOpen} onClose={() => setLoginOpen(false)} />
     </>
   );
 }

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -1,12 +1,21 @@
 import { Outlet } from 'react-router';
 import Header from './Header';
+import IsLoginModal from '../components/modals/IsLoginModal';
+import { useModalStore } from '../stores/modalStore';
 
 export default function MainLayout() {
+  const { isLogInOpen, setLogInModal } = useModalStore();
   return (
     <>
       <Header />
       <main>
         <Outlet />
+        {isLogInOpen && (
+          <IsLoginModal
+            isOpen={isLogInOpen}
+            onClose={() => setLogInModal(false)}
+          />
+        )}
       </main>
     </>
   );

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -137,7 +137,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
                   <>
                     <img
                       src={userInfo.avatar_url || userDefault}
-                      alt="사용자 이미지"
+                      alt="프로필"
                       className="h-10 w-10 rounded-full bg-white object-cover"
                     />
                     <div>

--- a/src/pages/problem/quiz/QuizProblemList.tsx
+++ b/src/pages/problem/quiz/QuizProblemList.tsx
@@ -4,13 +4,15 @@ import SearchBox from '../../../components/search/SearchBox';
 import SearchListTop from '../../../components/search/SearchListTop';
 import CheckItem from '../../../components/ui/CheckItem';
 import PageName from '../../../components/ui/PageName';
-import { useLoaderData } from 'react-router';
+import { useLoaderData, useNavigate } from 'react-router';
 import type { ChannelType, PostsType } from '../../../types';
 import { useEffect, useState } from 'react';
 import { getChannelPosts } from '../../../components/api/postApi';
 
 export default function QuizProblemList() {
   const channel = useLoaderData<ChannelType>();
+  const navigate = useNavigate();
+
   const [posts, setPosts] = useState<PostsType>([]);
   useEffect(() => {
     const fetchData = async () => {
@@ -23,6 +25,10 @@ export default function QuizProblemList() {
     };
     fetchData();
   }, [channel.id]);
+
+  const handleClick = () => {
+    navigate('/problems/write');
+  };
 
   return (
     <>
@@ -65,7 +71,10 @@ export default function QuizProblemList() {
               <QuizListCard image="asd" /> */}
             </div>
           </div>
-          <button className="bg-main fixed right-0 bottom-14 flex h-11 w-11 items-center justify-center rounded-full text-white shadow-md md:right-2 md:h-13 md:w-13 lg:right-6 lg:h-15 lg:w-15">
+          <button
+            onClick={handleClick}
+            className="bg-main fixed right-0 bottom-14 flex h-11 w-11 items-center justify-center rounded-full text-white shadow-md md:right-2 md:h-13 md:w-13 lg:right-6 lg:h-15 lg:w-15"
+          >
             <Plus className="h-5 w-5 lg:h-7 lg:w-7" />
           </button>
         </div>

--- a/src/pages/problem/quiz/QuizProblemList.tsx
+++ b/src/pages/problem/quiz/QuizProblemList.tsx
@@ -8,9 +8,13 @@ import { useLoaderData, useNavigate } from 'react-router';
 import type { ChannelType, PostsType } from '../../../types';
 import { useEffect, useState } from 'react';
 import { getChannelPosts } from '../../../components/api/postApi';
+import { useAuthStore } from '../../../stores/authStore';
+import { useModalStore } from '../../../stores/modalStore';
 
 export default function QuizProblemList() {
   const channel = useLoaderData<ChannelType>();
+  const session = useAuthStore((state) => state.session);
+  const { setLogInModal } = useModalStore();
   const navigate = useNavigate();
 
   const [posts, setPosts] = useState<PostsType>([]);
@@ -27,6 +31,10 @@ export default function QuizProblemList() {
   }, [channel.id]);
 
   const handleClick = () => {
+    if (!session?.user.id) {
+      setLogInModal(true);
+      return;
+    }
     navigate('/problems/write');
   };
 
@@ -65,10 +73,6 @@ export default function QuizProblemList() {
                   </h3>
                 </div>
               )}
-              {/* <QuizListCard solve={true} />
-              <QuizListCard image="asd" solve={true} />
-              <QuizListCard />
-              <QuizListCard image="asd" /> */}
             </div>
           </div>
           <button

--- a/src/pages/problem/quiz/QuizProblemList.tsx
+++ b/src/pages/problem/quiz/QuizProblemList.tsx
@@ -7,9 +7,13 @@ import PageName from '../../../components/ui/PageName';
 import { useLoaderData, useNavigate } from 'react-router';
 import type { ChannelType, PostsType } from '../../../types';
 import { useEffect, useState } from 'react';
-import { getChannelPosts } from '../../../components/api/postApi';
+import {
+  getChannelCategoryPosts,
+  getChannelPosts,
+} from '../../../components/api/postApi';
 import { useAuthStore } from '../../../stores/authStore';
 import { useModalStore } from '../../../stores/modalStore';
+import Loading from '../../../components/ui/Loading';
 
 export default function QuizProblemList() {
   const channel = useLoaderData<ChannelType>();
@@ -18,17 +22,31 @@ export default function QuizProblemList() {
   const navigate = useNavigate();
 
   const [posts, setPosts] = useState<PostsType>([]);
+  const [category, setCategory] = useState<string>('');
+  const [isPending, setPending] = useState(false);
+
   useEffect(() => {
     const fetchData = async () => {
+      setPending(true);
       try {
-        const channelPosts = await getChannelPosts(channel.id);
-        setPosts(channelPosts);
+        if (category === '') {
+          const channelPosts = await getChannelPosts(channel.id);
+          setPosts(channelPosts);
+        } else {
+          const channelPosts = await getChannelCategoryPosts(
+            channel.id,
+            category,
+          );
+          setPosts(channelPosts);
+        }
       } catch (e) {
         console.error(e);
+      } finally {
+        setPending(false);
       }
     };
     fetchData();
-  }, [channel.id]);
+  }, [channel.id, category]);
 
   const handleClick = () => {
     if (!session?.user.id) {
@@ -49,13 +67,15 @@ export default function QuizProblemList() {
         </div>
         <div>
           <div className="mb-2">
-            <p className="mb-1.5 text-sm md:text-base">카테고리 유형</p>
+            <p className="mb-1.5 text-sm md:text-base">
+              카테고리 유형: <b>{category}</b>
+            </p>
             <div className="flex flex-wrap gap-2.5">
               <div className="mb-4 flex flex-wrap gap-2.5">
-                <CheckItem id="1" title="프론트엔드" />
-                <CheckItem id="2" title="백엔드" />
-                <CheckItem id="3" title="모바일 앱" />
-                <CheckItem id="4" title="기타" />
+                <CheckItem id="1" title="프론트엔드" onChange={setCategory} />
+                <CheckItem id="2" title="백엔드" onChange={setCategory} />
+                <CheckItem id="3" title="모바일 앱" onChange={setCategory} />
+                <CheckItem id="4" title="기타" onChange={setCategory} />
               </div>
             </div>
           </div>
@@ -64,9 +84,13 @@ export default function QuizProblemList() {
               <SearchListTop />
             </div>
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-              {posts &&
-                posts.map((post) => <QuizListCard key={post.id} data={post} />)}
-              {posts && posts.length === 0 && (
+              {isPending ? (
+                <div className="col-span-2 text-center">
+                  <Loading />
+                </div>
+              ) : posts && posts.length > 0 ? (
+                posts.map((post) => <QuizListCard key={post.id} data={post} />)
+              ) : (
                 <div className="col-span-2 py-12 text-center">
                   <h3 className="t1 mb-2 font-medium text-black">
                     포스트가 없습니다.

--- a/src/pages/solution/quiz/QuizCreateEdit.tsx
+++ b/src/pages/solution/quiz/QuizCreateEdit.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router';
 import supabase from '../../../utils/supabase';
 import type { EditTextHandle } from '../../../components/edit/EditText.types';
 import { useRef } from 'react';
+import { notify } from '../../../utils/customAlert';
 
 export default function QuizCreateEdit() {
   const editTextRef = useRef<EditTextHandle>(null);
@@ -12,21 +13,17 @@ export default function QuizCreateEdit() {
   const handleSubmit = async () => {
     const postData = editTextRef.current?.getPostData();
     if (!postData) return;
-
-    const { title, content, imageUrl, imageFileName } = postData;
+    const { title, content, imageUrl, imageFileName, tags } = postData;
 
     const { data: userData } = await supabase.auth.getUser();
     const authorId = userData.user?.id;
-
-    if (!authorId) {
-      alert('로그인이 필요합니다.');
-      return;
-    }
+    if (!authorId) return;
 
     const { error } = await supabase.from('post').insert([
       {
         title,
         content,
+        tags,
         image: imageUrl,
         image_public_id: imageFileName,
         channel: 2,
@@ -39,9 +36,9 @@ export default function QuizCreateEdit() {
 
     if (error) {
       console.error('저장 실패', error);
-      alert('등록 실패');
+      notify('등록 실패!', 'warning');
     } else {
-      alert('등록 성공!');
+      notify('등록 성공!', 'success');
     }
     navigate('/problems/job');
   };
@@ -53,7 +50,12 @@ export default function QuizCreateEdit() {
         </div>
         <CreateQuiz ref={editTextRef} />
         <div className="mb-[25px] flex gap-3 md:mb-[35px] lg:justify-center">
-          <button className="button-lg gray">취소</button>
+          <button
+            onClick={() => navigate('/problems/job')}
+            className="button-lg gray"
+          >
+            취소
+          </button>
           <button onClick={handleSubmit} className="button-lg">
             작성하기
           </button>

--- a/src/pages/solution/quiz/QuizCreateEdit.tsx
+++ b/src/pages/solution/quiz/QuizCreateEdit.tsx
@@ -1,17 +1,62 @@
 import PageName from '../../../components/ui/PageName';
 import CreateQuiz from '../../../components/edit/CreateQuiz';
+import { useNavigate } from 'react-router';
+import supabase from '../../../utils/supabase';
+import type { EditTextHandle } from '../../../components/edit/EditText.types';
+import { useRef } from 'react';
 
 export default function QuizCreateEdit() {
+  const editTextRef = useRef<EditTextHandle>(null);
+  const navigate = useNavigate();
+
+  const handleSubmit = async () => {
+    const postData = editTextRef.current?.getPostData();
+    if (!postData) return;
+
+    const { title, content, imageUrl, imageFileName } = postData;
+
+    const { data: userData } = await supabase.auth.getUser();
+    const authorId = userData.user?.id;
+
+    if (!authorId) {
+      alert('로그인이 필요합니다.');
+      return;
+    }
+
+    const { error } = await supabase.from('post').insert([
+      {
+        title,
+        content,
+        image: imageUrl,
+        image_public_id: imageFileName,
+        channel: 2,
+        is_yn: true,
+        author: authorId,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ]);
+
+    if (error) {
+      console.error('저장 실패', error);
+      alert('등록 실패');
+    } else {
+      alert('등록 성공!');
+    }
+    navigate('/problems/job');
+  };
   return (
     <>
       <div className="px-4 py-[25px] md:px-8 md:py-[35px] lg:px-14 lg:py-[45px] xl:mx-auto xl:max-w-6xl xl:px-0">
         <div className="mb-[25px] md:mb-[35px]">
           <PageName title="문제 만들기" />
         </div>
-        <CreateQuiz />
+        <CreateQuiz ref={editTextRef} />
         <div className="mb-[25px] flex gap-3 md:mb-[35px] lg:justify-center">
           <button className="button-lg gray">취소</button>
-          <button className="button-lg">작성하기</button>
+          <button onClick={handleSubmit} className="button-lg">
+            작성하기
+          </button>
         </div>
       </div>
     </>

--- a/src/pages/solution/quiz/QuizCreateEdit.tsx
+++ b/src/pages/solution/quiz/QuizCreateEdit.tsx
@@ -2,18 +2,26 @@ import PageName from '../../../components/ui/PageName';
 import CreateQuiz from '../../../components/edit/CreateQuiz';
 import { useNavigate } from 'react-router';
 import supabase from '../../../utils/supabase';
-import type { EditTextHandle } from '../../../components/edit/EditText.types';
-import { useRef } from 'react';
+import type { CreateQuizHandle } from '../../../components/edit/EditText.types';
+import { useRef, useState } from 'react';
 import { notify } from '../../../utils/customAlert';
 
 export default function QuizCreateEdit() {
-  const editTextRef = useRef<EditTextHandle>(null);
+  const editTextRef = useRef<CreateQuizHandle>(null);
   const navigate = useNavigate();
+  const [quizValid, setQuizValid] = useState<boolean>(false);
 
   const handleSubmit = async () => {
     const postData = editTextRef.current?.getPostData();
     if (!postData) return;
-    const { title, content, imageUrl, imageFileName, tags } = postData;
+    const { title, content, imageUrl, imageFileName, tags, quizData } =
+      postData;
+
+    if (title === '') return notify('제목을 입력하세요!', 'info');
+    if (content === '') return notify('내용을 입력하세요!', 'info');
+    if (quizData.length === 0)
+      return notify('최소 1개의 퀴즈를 추가하셔야 합니다.', 'info');
+    if (!quizValid) return notify('퀴즈를 완성하세요!', 'warning');
 
     const { data: userData } = await supabase.auth.getUser();
     const authorId = userData.user?.id;
@@ -31,6 +39,7 @@ export default function QuizCreateEdit() {
         author: authorId,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
+        quiz_data: quizData,
       },
     ]);
 
@@ -48,7 +57,10 @@ export default function QuizCreateEdit() {
         <div className="mb-[25px] md:mb-[35px]">
           <PageName title="문제 만들기" />
         </div>
-        <CreateQuiz ref={editTextRef} />
+        <CreateQuiz
+          ref={editTextRef}
+          quizValid={(valid) => setQuizValid(valid)}
+        />
         <div className="mb-[25px] flex gap-3 md:mb-[35px] lg:justify-center">
           <button
             onClick={() => navigate('/problems/job')}

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+interface ModalState {
+  isLogInOpen: boolean;
+  isLogOutOpen: boolean;
+
+  setLogInModal: (isOpen: boolean) => void;
+  setLogOutModal: (isOpen: boolean) => void;
+}
+
+export const useModalStore = create<ModalState>((set) => ({
+  isLogInOpen: false,
+  isLogOutOpen: false,
+
+  setLogInModal: (isOpen) => set({ isLogInOpen: isOpen }),
+  setLogOutModal: (isOpen) => set({ isLogOutOpen: isOpen }),
+}));

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -356,6 +356,8 @@ export type Database = {
           image: string | null;
           image_public_id: string | null;
           is_yn: boolean;
+          quiz_data: Json[] | null;
+          solved_problem_id: number | null;
           tags: string[] | null;
           title: string | null;
           updated_at: string;
@@ -369,6 +371,8 @@ export type Database = {
           image?: string | null;
           image_public_id?: string | null;
           is_yn?: boolean;
+          quiz_data?: Json[] | null;
+          solved_problem_id?: number | null;
           tags?: string[] | null;
           title?: string | null;
           updated_at?: string;
@@ -382,6 +386,8 @@ export type Database = {
           image?: string | null;
           image_public_id?: string | null;
           is_yn?: boolean;
+          quiz_data?: Json[] | null;
+          solved_problem_id?: number | null;
           tags?: string[] | null;
           title?: string | null;
           updated_at?: string;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -358,6 +358,7 @@ export type Database = {
           is_yn: boolean;
           quiz_data: Json[] | null;
           solved_problem_id: number | null;
+          solved_problem_level: number | null;
           tags: string[] | null;
           title: string | null;
           updated_at: string;
@@ -373,6 +374,7 @@ export type Database = {
           is_yn?: boolean;
           quiz_data?: Json[] | null;
           solved_problem_id?: number | null;
+          solved_problem_level?: number | null;
           tags?: string[] | null;
           title?: string | null;
           updated_at?: string;
@@ -388,6 +390,7 @@ export type Database = {
           is_yn?: boolean;
           quiz_data?: Json[] | null;
           solved_problem_id?: number | null;
+          solved_problem_level?: number | null;
           tags?: string[] | null;
           title?: string | null;
           updated_at?: string;


### PR DESCRIPTION
## ✨ PR 개요

퀴즈를 생성하고 supabase에 저장합니다.

---

## 🛠️ 작업 상세 내용

이번 PR에서 수행한 작업 유형에 체크해 주세요.

- [x] New Feature (새 기능 추가)
- [ ] Bug Fix (버그 수정)
- [ ] Remove Feature (기능 제거)
- [x] Change Logic (로직 수정)
- [x] Style (스타일 수정: 코드 포맷, CSS 등)
- [ ] Test (테스트 코드 추가/수정)
- [ ] Set up (환경 설정, 패키지 설정 등)

---

## 🔥 작업 내용 및 관련 이슈

- 기존의 정우님 게시판 양식을 사용하여, 퀴즈 생성이 가능해졌습니다.
- 개발직군 문제는 카테고리 선택으로, 넷 중에 하나만 선택해야하므로 라디오버튼 속성으로 바꿨습니다.
- 퀴즈 등의 내용이 누락되면 생성되지 않는 로직을 추가했습니다.
- 카테고리 별로 문제를 나눠볼 수 있는 기능을 추가했습니다.
- 추가로, 데이터를 가져올 때 로딩 UI를 보여줍니다.

---

## 📜 새로 설치한 패키지 목록
![image](https://github.com/user-attachments/assets/17bba15e-1e92-4a0f-831f-1a521c31da91)
https://www.davidhu.io/react-spinners/storybook/?path=/docs/fadeloader--docs
- 로딩화면 구성을 위한 react-spinners 패키지를 추가 설치.
```bash
npm install react-spinners --save
```

---

## 📸 스크린샷 (선택)


https://github.com/user-attachments/assets/609f1dcf-e700-421d-984a-65bd2b223261



---

## ✍️ 리뷰 시 참고 사항
![image](https://github.com/user-attachments/assets/bfa13a40-b213-4cd8-9809-41baefda66a8)
- 퀴즈 데이터는 위와 같이 post 테이블의 quiz_data 컬럼에 들어갑니다.
- 문제 푸는 페이지는 후에 바로 구현 예정입니다.

